### PR TITLE
Correctly define plugin name

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var postcss = require('postcss');
 
-module.exports = postcss.plugin('postcss-reverse-props', options => {
+module.exports = postcss.plugin('postcss-safe-important', options => {
     options = options || {};
     // default options
     var excludeRules = new Set();


### PR DESCRIPTION
Whilst debugging another issue using [postcss-debug](https://github.com/andywer/postcss-debug) I was confused by a postcss plugin called `postcss-reverse-props`. This PR correctly defines the plugin name as `postcss-safe-important`.